### PR TITLE
Hotkey to show hidden messages

### DIFF
--- a/Bindings.xml
+++ b/Bindings.xml
@@ -1,0 +1,5 @@
+<Bindings>
+	<Binding name="DETOX_SHOW_MESSAGES" header="DETOX" category="ADDONS" default="CTRL-G">
+		Detox.ShowHiddenChats()
+	</Binding>
+</Bindings>

--- a/Detox.toc
+++ b/Detox.toc
@@ -1,7 +1,7 @@
 ## Interface: 90002
 ## Title: Detox
 ## Author: Vinnesta
-## Version: 1.1
+## Version: 1.2
 
 ## SavedVariables: DetoxDB
 

--- a/README.md
+++ b/README.md
@@ -6,5 +6,6 @@ Detox is an addon for World of Warcraft that automatically hides toxic chat mess
 - Whitelist players so their messages are never filtered
 - Friends and guild members are automatically whitelisted
 - Enable/disable filtering on certain channels, e.g. Guild chat
+- Hotkey to show hidden messages (default is Ctrl-G)
 
 Never have your day ruined again by an unprompted whisper saying "you suck!" after a dungeon, raid, battleground, or arena match.

--- a/config.lua
+++ b/config.lua
@@ -1,5 +1,8 @@
 local _, addonTbl = ...
 
+BINDING_HEADER_DETOX = "Detox"
+BINDING_NAME_DETOX_SHOW_MESSAGES = "Show Detox Messages"
+
 local AceGUI = LibStub("AceGUI-3.0")
 local config = {}
 
@@ -87,6 +90,7 @@ config.detoxOptions = {
 							name = "Show Notifications",
 							desc = "If disabled, you will not be notified of hidden toxic messages. Use at your own risk!",
 							type = "toggle",
+							order = 10,
 							set = function(info, val) Detox.db.profile.showNotification = val end,
 							get = function(info) return Detox.db.profile.showNotification end
 						}

--- a/main.lua
+++ b/main.lua
@@ -96,7 +96,7 @@ end)
 function Detox:OnInitialize()
 	self.enabled = true
 	
-	self.db = LibStub("AceDB-3.0"):New("DetoxDB", { profile = config.profileDefaults() })
+	self.db = LibStub("AceDB-3.0"):New("DetoxDB", { profile = config.profileDefaults() }, true)
 	self.db.RegisterCallback(self, "OnProfileChanged", "RefreshConfig")
 	self.db.RegisterCallback(self, "OnProfileCopied", "RefreshConfig")
 	self.db.RegisterCallback(self, "OnProfileReset", "RefreshConfig")
@@ -133,6 +133,23 @@ function Detox:RefreshConfig()
 	end
 end
 
+function Detox:ShowHiddenChats()
+	local sortedIds = {}
+	for id, chat in pairs(detoxHiddenChats) do
+		if not chat.shown then
+			table.insert(sortedIds, id)
+		end
+	end
+	table.sort(sortedIds)
+	
+	for _, id in ipairs(sortedIds) do
+		local chat = detoxHiddenChats[id]
+		Print(RecreateChat(chat), SELECTED_CHAT_FRAME)
+		chat.shown = true
+		detoxHiddenChats[id] = chat
+	end
+end
+
 Detox:RegisterChatCommand("detox", "SlashProcessorFunc")
 Detox:RegisterChatCommand("dtx", "SlashProcessorFunc")
 
@@ -150,13 +167,7 @@ function Detox:SlashProcessorFunc(input)
 	end
 	
 	if command == 'show' then
-		for k, chat in pairs(detoxHiddenChats) do
-			if not chat.shown then
-				Print(RecreateChat(chat), SELECTED_CHAT_FRAME)
-				chat.shown = true
-				detoxHiddenChats[k] = chat
-			end
-		end
+		self:ShowHiddenChats()
 	end
 end
 


### PR DESCRIPTION
- Keybind to show messages without having to click (default Ctrl-G)
- Change profile to be account-wide default instead of character specific