### PR TITLE
Support for WoW Classic

### DIFF
--- a/Bindings.xml
+++ b/Bindings.xml
@@ -1,5 +1,5 @@
 <Bindings>
-	<Binding name="DETOX_SHOW_MESSAGES" header="DETOX" category="ADDONS" default="CTRL-G">
+	<Binding name="DETOX_SHOW_MESSAGES" header="DETOX" category="ADDONS">
 		Detox.ShowHiddenChats()
 	</Binding>
 </Bindings>

--- a/Detox.toc
+++ b/Detox.toc
@@ -1,7 +1,7 @@
 ## Interface: 90005
 ## Title: Detox
 ## Author: Vinnesta
-## Version: 1.2
+## Version: 2.1.1
 
 ## SavedVariables: DetoxDB
 

--- a/classifier.lua
+++ b/classifier.lua
@@ -253,6 +253,7 @@ function classifier:GetEmbeddings(tokens)
 						origCopy.rank = origCopy.rank + index[i]
 						tinsert(origCopy, wordEmbedding)
 					end
+					tinsert(alternativeTokensEmbeddings, origCopy)
 				else
 					-- Index represents how common the word is; 0 = does not have embedding (UNK/OOV)
 					-- If the alternative word is OOV, it does not need to be added to the list since the original token is also OOV
@@ -260,9 +261,9 @@ function classifier:GetEmbeddings(tokens)
 						local wordEmbedding = embeddings[word] or unk
 						origCopy.rank = origCopy.rank + index
 						tinsert(origCopy, wordEmbedding)
+						tinsert(alternativeTokensEmbeddings, origCopy)
 					end
 				end
-				tinsert(alternativeTokensEmbeddings, origCopy)
 			end
 		end
 		

--- a/config.lua
+++ b/config.lua
@@ -153,7 +153,7 @@ config.detoxOptions = {
 							get = function(info) return Detox.db.profile.whitelistGuild end
 						},
 						whitelistPlayersDescription = {
-							name = "\nAdd specific players to whitelist (must include realm name, e.g. PlayerName-Realm)",
+							name = "\nAdd specific players to whitelist",
 							type = "description",
 							order = 50
 						},
@@ -195,7 +195,7 @@ end
 
 function config:IsWhitelisted(name)
 	for _, player in ipairs(self.whitelist) do
-		if name == player.name then
+		if string.lower(name) == string.lower(player.name) then
 			return true
 		end
 	end
@@ -216,7 +216,7 @@ function config:ShowWhitelistFrame()
 	frame:SetLayout("Flow")
 	
 	local whitelistEditbox = AceGUI:Create("EditBox")
-	whitelistEditbox:SetLabel("Whitelist (PlayerName-Realm):")
+	whitelistEditbox:SetLabel("Whitelist (CharacterName):")
 	whitelistEditbox:SetRelativeWidth(0.78)
 	whitelistEditbox:SetCallback("OnEnterPressed", function(widget, event, text) self:AddToWhitelist(text); widget:SetText("") end)
 	frame:AddChild(whitelistEditbox)


### PR DESCRIPTION
- Update APIs to be compatible with Classic client
- Whitelist of named players no longer need to contain realm name
- Hotkey for showing messages is set only if not bound to another action
- Fix bug with word embeddings being tested incorrectly